### PR TITLE
Fixes for v0.4, eltype dict is not a tuple

### DIFF
--- a/src/URITemplate.jl
+++ b/src/URITemplate.jl
@@ -17,7 +17,7 @@ module URITemplate
     				 ch == '\''|| ch == '(' || ch == ')' || ch == '*' || ch == '+' ||
     				 ch == ',' || ch == ';' || ch == '='
 
-	pctencode(s::IO,c::Uint8) = write(s,'%',base(16,c,2))
+	pctencode(s::IO,c::UInt8) = write(s,'%',base(16,c,2))
 
 	function pctencode(s::IO, c::Char, allowR = false)
 	    if c < 0x80
@@ -49,7 +49,7 @@ module URITemplate
 	    end
 	end
 
-	function pctencode(s::IO, string::String, allowR = false)
+	function pctencode(s::IO, string::AbstractString, allowR = false)
 		for c in string
 			pctencode(s,c,allowR)
 		end
@@ -79,8 +79,8 @@ module URITemplate
 
 
 
-	function expand(template::String,variables)
-		if !( keytype( variables ) <: String)
+	function expand(template::AbstractString,variables)
+		if !( keytype( variables ) <: AbstractString)
 			variables = [string(k) => v for (k,v) in variables]
 		end
 
@@ -232,7 +232,7 @@ module URITemplate
 						write(out,sep)
 					end
 					val = variables[varname]
-					if isa(val,String)
+					if isa(val,AbstractString)
 						if named
 							write(out,varname)
 							if isempty(val)

--- a/src/URITemplate.jl
+++ b/src/URITemplate.jl
@@ -64,20 +64,14 @@ module URITemplate
 		return true
 	end
 
-	if VERSION < v"0.4.0-dev"
+	if VERSION < v"0.4.0"
 		# eltype of Dict is now pair and not a Tuple
 		function keytype( dict )
 			return eltype(dict)[1]
 		end
 		# Size hint is replaced by sizehint!
 		sizehint! = sizehint
-	else
-		function keytype( dict )
-			return eltype( dict ).parameters[1]
-		end
 	end
-
-
 
 	function expand(template::AbstractString,variables)
 		if !( keytype( variables ) <: AbstractString)


### PR DESCRIPTION
Two small fixes to make URITemplate work on v0.4 